### PR TITLE
Removed milquetoast and irrelevant info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Manuscripta Website
 
-The project documentation site for the Manuscripta educational technology platform.
+The project documentation site for Manuscripta, the accessible educational platform that combines AI-powered e-learning with distraction-free e-ink displays.
 
 View the website live [here](https://priyabargota.github.io/manuscripta-website/) and check out Manuscripta [here](https://github.com/raphaellith/Manuscripta).


### PR DESCRIPTION
This PR removes the milquetoast and mostly irrelevant information from the README file, which currently is mostly focused on basic HTML/CSS/JS editing and Git use.

Instead, I've included the following in the README:

1. a tagline for our project, based on our BETT conference script;
1. the link to the GitHub Pages site; and
1. the link to the Manuscripta repo.

Let me know if there's anything I should add to the README as well.

The link to the GitHub Pages site will have to be replaced when the site is deployed on UCL servers. On that note, should we temporarily include the link in this repo's About section? Or should we do that with the UCL-based link after it's deployed? I think only @PriyaBargota is allowed to edit the About section.