### PR TITLE
chore: Add .gitignore to exclude common build outputs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+build/
+dist/
+out/
+*.log


### PR DESCRIPTION
Added a gitignore file that ignores common build files and .Ds store